### PR TITLE
Run time in red only when on battery

### DIFF
--- a/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
+++ b/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
@@ -42,7 +42,7 @@ if (file_exists('/var/run/nut/upsmon.pid')) {
       break;
     case 'battery.runtime':
       $runtime   = gmdate("H:i:s", $val);
-      $status[2] = strtok($val/60,' ')<=5 ? "<td $red>$runtime</td>" : "<td $green>$runtime</td>";
+      $status[2] = strtok($val/60,' ')<=5 && !in_array('ups.status: OL', $rows) ? "<td $red>$runtime</td>" : "<td $green>$runtime</td>";
       break;
     case 'ups.realpower.nominal':
       $power     = strtok($val,' ');


### PR DESCRIPTION
Noticed that run time goes red if it is less than 5 minutes when UPS is online, implying power is lost and battery running low. It would make sense to show things in red, only when critical. The PR is not the best approach to the problem, but "oh well, it works". Refactoring the parser would allow for cleaner references and easier work in future iterations ([example](https://github.com/realies/corsairpsu-unraid/blob/master/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.php)).